### PR TITLE
#007 시간에 따라 Ready Queue 업데이트하도록 수정

### DIFF
--- a/lab1_sched/include/lab1_sched_types.h
+++ b/lab1_sched/include/lab1_sched_types.h
@@ -31,6 +31,9 @@ typedef struct _process {
 	int	color;
 	int	arrival;
 	int	service;
+	int	start;
+	int	remain;
+	int	finish;
 } process;
 
 /*
@@ -41,7 +44,6 @@ typedef struct _sched_process {
 	int	color;
 	int	start;
 	int	running;
-	int	finish;
 } sched_process;
 
 typedef	struct _node {
@@ -94,6 +96,7 @@ int GetSchedTableTopAlign();
 void Init();
 void InitSchedMenu();
 void CreateProcessArr();	
+void SortProcessArrByArrivalTime();
 
 
 /*
@@ -114,9 +117,11 @@ void FreeQueue(queue *q);
  */
 sched_process* NewSchedProcess(process *source, int start, int running);
 
-void SortReadyQueueByArrivalTime();
 void RunScheduling(int num);
+void UpdateReadyQueue(int now, process *proc);
 void PrintResultQueue();
+
+node* GetShortestProcNodeInReadyQueue();
 
 
 /*
@@ -124,6 +129,7 @@ void PrintResultQueue();
  */
 void FCFS();
 void SJF();
+
 #endif /* LAB1_HEADER_H*/
 
 


### PR DESCRIPTION
## 개요
current time 을 기준으로 `ready_queue` 를 update 하도록 코드 수정


## 상세

```
기존 코드: 모든 프로세스를 Arrival Time 을 기준으로 정렬하여 미리 Ready Queue 에 넣어놓는 방식
```

**기존 코드의 문제점**

선점형 스케줄링을 구현할 때 Run 상태의 프로세스를 다시 Ready Queue 에 넣으려면 아직 생성되지 않은 프로세스의 앞에 insert 해야됨 -> 큐 탐색, 재정렬 필요함  (비효율적)👎

**Ready Queue 생성 및 정렬 방식 변경**

모든 프로세스를 Arrival Time 을 기준으로 정렬하여 Ready Queue 에는 넣지 않고 배열 형태로 저장
스케줄링 알고리즘 내에서 시간에 따라 큐 업데이트
-> 시간 흐름을 나타내는 변수 `now` 가 +1 될 때마다 `UpdateReadyQueue` 호출
```
...
    // 1초에 한 번씩 Ready Queue 업데이트
    for(int i = 0 ; i < service_time ; i++) {
        UpdateReadyQueue(++now, NULL);
    }    
....
```

**UpdateReadyQueue**
```
void UpdateReadyQueue(int now, process *proc)
```

- `now` 시간을 기준으로 레디 큐 수정
- Service Time 이 남아있는 Ready 상태의 프로세스를 담음
- 파라미터
     * now : 현재 시간
     * proc: Timeout 프로세스
- 정렬 기준: 
      1. 새로운 프로세스: 방금 도착한 프로세스 (now = Arrival Time)
      2. Timeout 프로세스: Run -> Ready 상태 변화한 프로세스